### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ ASScroll View is an ios control  which scroll between image with fading animatio
 ## Requirements
 ios 4.1 or later
 
-###Manual
+### Manual
 1. Check out the project
 2. Add all files in `ASScroll` folder to Xcode
 
-##Usage
+## Usage
 1. Import `ASScroll.h` in your view controller
 2. Implement  ASScroll
 	  


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
